### PR TITLE
Allow input nodes to do I/O

### DIFF
--- a/src/demo.ts
+++ b/src/demo.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
-import { Graph, GraphReader, GraphSpec } from './graph';
+import { Graph, GraphReader, GraphSpec, INPUT, RULE } from './graph';
 
 /*
 PROBLEM DESCRIPTION:
@@ -18,32 +18,35 @@ const PARSE_LST = "PARSE_LST"; // string[]
 const PARSE_DAT = "PARSE_DAT"; // number
 const EVALUATE_LST = "EVALUATE_LST"; // number
 
+const files : {[k : string] : string} = {};
+
 const spec: GraphSpec = {
-    [FILE_CONTENTS]: null,
-    [PARSE_LST]: (g: GraphReader, file: string): string[] => {
+    [FILE_CONTENTS]: {kind: INPUT, fn : (file : string) => {
+        return files[file];
+    }},
+    [PARSE_LST]:  {kind: RULE, fn : (g: GraphReader, file: string): string[] => {
         const contents = g.get_value(FILE_CONTENTS, file) as string;
         console.log(`${PARSE_LST}(${file})`);
         return contents.split(",");
-    },
-    [PARSE_DAT]: (g: GraphReader, file: string): number => {
+    }},
+    [PARSE_DAT]: {kind: RULE, fn: (g: GraphReader, file: string): number => {
         const contents = g.get_value(FILE_CONTENTS, file) as string;
         console.log(`${PARSE_DAT}(${file})`);
         return Number.parseInt(contents.trim());
-    },
-    [EVALUATE_LST]: (g: GraphReader, file: string): number => {
+    }},
+    [EVALUATE_LST]: {kind: RULE, fn: (g: GraphReader, file: string): number => {
         const list = g.get_value(PARSE_LST, file) as string[];
         const numbers = list.map(item => g.get_value(PARSE_DAT, item) as number);
         console.log(`${EVALUATE_LST}(${file})`);
         return numbers.reduce((x, y) => x + y, 0);
     },
-};
-
+}};
 
 const g = new Graph(spec);
 
-g.set_input(FILE_CONTENTS, "main.lst", "foo.dat,bar.dat");
-g.set_input(FILE_CONTENTS, "foo.dat", "13");
-g.set_input(FILE_CONTENTS, "bar.dat", "42");
+files["main.lst"] = "foo.dat,bar.dat";
+files["foo.dat"] = "13";
+files["bar.dat"] = "42";
 console.log(`=> ${g.get_value(EVALUATE_LST, "main.lst")}`);
 // expected output:
 // PARSE_LST(main.lst)
@@ -52,14 +55,14 @@ console.log(`=> ${g.get_value(EVALUATE_LST, "main.lst")}`);
 // EVALUATE_LST(main.lst)
 // => 55
 
-g.set_input(FILE_CONTENTS, "bar.dat", "24");
+files["bar.dat"] = "24";
 console.log(`=> ${g.get_value(EVALUATE_LST, "main.lst")}`);
 // expected output:
 // PARSE_DAT(bar.dat)
 // EVALUATE_LST(main.lst)
 // => 37
 
-g.set_input(FILE_CONTENTS, "bar.dat", "  24  ");
+files["bar.dat"] = "  24  ";
 console.log(`=> ${g.get_value(EVALUATE_LST, "main.lst")}`);
 // expected output:
 // PARSE_DAT(bar.dat)
@@ -68,10 +71,9 @@ console.log(`=> ${g.get_value(EVALUATE_LST, "main.lst")}`);
 console.log(`=> ${g.get_value(EVALUATE_LST, "main.lst")}`);
 // expected output:
 // => 37
-
-g.set_input(FILE_CONTENTS, "main.lst", "foo.dat,baz.dat");
-g.set_input(FILE_CONTENTS, "bar.dat", "17");
-g.set_input(FILE_CONTENTS, "baz.dat", "0");
+files["main.lst"] = "foo.dat,baz.dat";
+files["foo.dat"] = "13";
+files["baz.dat"] = "0";
 console.log(`=> ${g.get_value(EVALUATE_LST, "main.lst")}`);
 // expected output:
 // PARSE_LST(main.lst)

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -8,7 +8,16 @@ export interface GraphReader {
 
 type Rule = (reader: GraphReader, file: string) => unknown
 
-export type GraphSpec = {[layer: string]: Rule | null}
+type Input = (file: string) => unknown
+
+type LayerKind = string
+
+type LayerSpec = {kind: LayerKind, fn: Input | Rule}
+
+export type GraphSpec = {[layer: string]: LayerSpec}
+
+export const INPUT : LayerKind = "INPUT";
+export const RULE : LayerKind = "RULE";
 
 type Time = number
 
@@ -20,15 +29,17 @@ type NodeId = {
 interface Node {
     value: unknown;
     change_at: Time;
+    updated_at: Time;
 }
 type InputNode = Node
 type RuleNode = Node & {
     dependencies: NodeId[];
-    updated_at: Time;
+    input_dependencies: NodeId[];
 }
 
 type InputLayer = {
     nodes: Map<string, InputNode>; // string is a file
+    rule: Input
 }
 type RuleLayer = {
     nodes: Map<string, RuleNode>; // string is a file
@@ -45,43 +56,44 @@ export class Graph implements GraphReader {
         this.input_layers = new Map<string, InputLayer>();
         this.rule_layers = new Map<string, RuleLayer>();
         for (const layer in spec) {
-            const rule = spec[layer];
-            if (rule === null) {
-                this.input_layers.set(layer, {nodes: new Map<string, InputNode>()});
+            const layerSpec = spec[layer];
+            if (layerSpec.kind === INPUT) {
+                this.input_layers.set(layer, {rule : <Input> layerSpec.fn, nodes: new Map<string, InputNode>()});
             } else {
-                this.rule_layers.set(layer, {rule, nodes: new Map<string, RuleNode>()});
+                this.rule_layers.set(layer, {rule: <Rule> layerSpec.fn, nodes: new Map<string, RuleNode>()});
             }
         }
     }
 
-    set_input(layer: string, file: string, value: unknown): void {
-        const {nodes} = this.input_layers.get(layer)!;
+    private set_input(layer: string, file: string): void {
+        const {nodes, rule} = this.input_layers.get(layer)!;
         if (!nodes.has(file)) {
-            this.now += 1;
             nodes.set(file, {
-                value,
+                value: rule(file),
                 change_at: this.now,
+                updated_at: this.now,
             });
         }
         const node = nodes.get(file)!;
+        const value = rule(file);
+        node.updated_at = this.now;
         if (deepEqual(node.value, value)) {
             return;
         }
-        this.now += 1;
         node.value = value;
         node.change_at = this.now;
     }
 
     get_value(layer: string, file: string): unknown {
+        this.now += 1;
         return this.update_node(layer, file).value;
     }
 
     private update_node(layer: string, file: string): Node {
         if (this.input_layers.has(layer)) {
             const {nodes} = this.input_layers.get(layer)!;
-            if (!nodes.has(file)) {
-                throw Error(`Accessing unset input node ${layer}(${file})`);
-            }
+            if (!nodes.has(file) || nodes.get(file)!.updated_at < this.now)
+                this.set_input(layer, file)
             return nodes.get(file)!;
         }
 
@@ -93,6 +105,7 @@ export class Graph implements GraphReader {
                 value,
                 change_at: this.now,
                 dependencies: reader.trace,
+                input_dependencies: this.get_input_dependencies(reader.trace),
                 updated_at: this.now,
             };
             nodes.set(file, node);
@@ -101,6 +114,19 @@ export class Graph implements GraphReader {
 
         const node = nodes.get(file)!;
         if (node.updated_at === this.now) {
+            return node;
+        }
+
+        let input_dependencies_changed = false;
+        for (const dep of node.input_dependencies) {
+            if (this.update_node(dep.layer, dep.file).change_at > node.updated_at) {
+                input_dependencies_changed = true;
+                break;
+            }
+        }
+
+        if (!input_dependencies_changed) {
+            node.updated_at = this.now;
             return node;
         }
 
@@ -124,16 +150,40 @@ export class Graph implements GraphReader {
             node.change_at = this.now;
         }
         node.dependencies = reader.trace;
+        node.input_dependencies = this.get_input_dependencies(reader.trace);
         node.updated_at = this.now;
         return node;
+    }
+
+    private get_input_dependencies(dependencies: NodeId[]) : NodeId[] {
+        
+        const input_dependency_map : {[layer: string] : {[file: string]: {}}} = {};
+        for(const dep of dependencies) {
+            if(this.input_layers.has(dep.layer)) {
+                if (input_dependency_map[dep.layer] === undefined) input_dependency_map[dep.layer] = {};
+                input_dependency_map[dep.layer][dep.file] = {};
+            } else {
+                for(const input_dep of this.rule_layers.get(dep.layer)!.nodes.get(dep.file)!.input_dependencies) {
+                    if (input_dependency_map[input_dep.layer] === undefined) input_dependency_map[input_dep.layer] = {};
+                    input_dependency_map[input_dep.layer][input_dep.file] = {};
+                }
+            }
+        }
+
+        const ret : NodeId[] = [];
+        for(const layer in input_dependency_map)
+            for (const file in input_dependency_map[layer])
+                ret.push({layer, file});
+        return ret;
     }
 
     private get_traced_reader(): GraphReader & {trace: NodeId[]} {
         const trace: NodeId[] = [];
         const get_value = (layer: string, file: string): unknown => {
             trace.push({layer, file});
-            return this.get_value(layer, file);
+            return this.update_node(layer, file).value;
         };
+
         return {get_value, trace};
     }
 }


### PR DESCRIPTION
By tracking the relevant input nodes on every rule node, the build system can "pull" on inputs rather than relying on being pushed updates. On the one hand, this makes it more flexible, but on the other hand, it also allows for faster short-circuiting if relevant inputs have not changed.